### PR TITLE
Adding rx operator for firebase instance id

### DIFF
--- a/app/src/main/java/durdinapps/rxfirebase2/RxFirebaseMessaging.java
+++ b/app/src/main/java/durdinapps/rxfirebase2/RxFirebaseMessaging.java
@@ -1,0 +1,29 @@
+package durdinapps.rxfirebase2;
+
+import android.support.annotation.NonNull;
+
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+
+import io.reactivex.Maybe;
+import io.reactivex.MaybeEmitter;
+import io.reactivex.MaybeOnSubscribe;
+
+public class RxFirebaseMessaging {
+
+    /**
+     * Asynchronously retrieves from an instanceIdResult from the {@link com.google.firebase.iid.FirebaseInstanceId}
+     *
+     * @param instanceId the firebase instanceId object
+     * @return a {@link Maybe} which emits an {@link com.google.firebase.iid.InstanceIdResult} if successful
+     */
+    @NonNull
+    public static Maybe<InstanceIdResult> getInstanceId(@NonNull final FirebaseInstanceId instanceId) {
+        return Maybe.create(new MaybeOnSubscribe<InstanceIdResult>() {
+            @Override
+            public void subscribe(MaybeEmitter<InstanceIdResult> emitter) throws Exception {
+                RxHandler.assignOnTask(emitter, instanceId.getInstanceId());
+            }
+        });
+    }
+}

--- a/app/src/test/java/durdinapps/rxfirebase2/RxFirebaseMessagingTest.java
+++ b/app/src/test/java/durdinapps/rxfirebase2/RxFirebaseMessagingTest.java
@@ -1,0 +1,69 @@
+package durdinapps.rxfirebase2;
+
+import com.google.android.gms.tasks.Task;
+import com.google.firebase.iid.FirebaseInstanceId;
+import com.google.firebase.iid.InstanceIdResult;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import io.reactivex.observers.TestObserver;
+
+import static durdinapps.rxfirebase2.RxTestUtil.EXCEPTION;
+import static durdinapps.rxfirebase2.RxTestUtil.setupTask;
+import static durdinapps.rxfirebase2.RxTestUtil.testOnCompleteListener;
+import static durdinapps.rxfirebase2.RxTestUtil.testOnFailureListener;
+import static durdinapps.rxfirebase2.RxTestUtil.testOnSuccessListener;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RxFirebaseMessagingTest {
+
+    @Mock
+    private Task<InstanceIdResult> instanceIdResultTask;
+
+    @Mock
+    private FirebaseInstanceId instanceId;
+
+    @Mock
+    private InstanceIdResult instanceIdResult;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        setupTask(instanceIdResultTask);
+
+        when(instanceId.getInstanceId()).thenReturn(instanceIdResultTask);
+    }
+
+    @Test
+    public void getInstanceId() {
+        TestObserver<InstanceIdResult> instanceIdObserver = RxFirebaseMessaging.getInstanceId(instanceId).test();
+
+        testOnSuccessListener.getValue().onSuccess(instanceIdResult);
+        testOnCompleteListener.getValue().onComplete(instanceIdResultTask);
+
+        verify(instanceId).getInstanceId();
+
+        instanceIdObserver.assertComplete()
+                .assertNoErrors()
+                .assertValueCount(1)
+                .dispose();
+
+    }
+
+    @Test
+    public void getInstanceIdError() {
+        TestObserver<InstanceIdResult> instanceIdObserver = RxFirebaseMessaging.getInstanceId(instanceId).test();
+
+        testOnFailureListener.getValue().onFailure(EXCEPTION);
+        verify(instanceId).getInstanceId();
+
+        instanceIdObserver.assertError(EXCEPTION)
+                .dispose();
+
+    }
+}


### PR DESCRIPTION
Maybe<> operator for getting the instance id, for use in cases where you need the token on demand. Placed in RxFirebaseMessaging namespace since it is featured mainly on https://firebase.google.com/docs/cloud-messaging/android/client. 